### PR TITLE
feat: implement connection as plugin prop

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -27,7 +27,7 @@ function EncryptionPlugin(schema, plugin) {
 
   const keyAltName = plugin.keyAltName || 'encryption_key';
   const keyVaultNamespace = plugin.keyVaultNamespace || 'encryption.__keyVault';
-  const kmsProviders = {
+  const kmsProviders = plugin.kmsProviders || {
     local: {
       key: SECRET_KEY,
     },

--- a/lib/index.js
+++ b/lib/index.js
@@ -21,12 +21,12 @@ function EncryptionPlugin(schema, plugin) {
   const encryptFields = [];
 
   const SECRET_KEY = plugin.secret;
+  const connection = plugin.connection || mongoose.connection;
   const algorithm =
     plugin.algorithm || 'AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic';
 
   const keyAltName = plugin.keyAltName || 'encryption_key';
   const keyVaultNamespace = plugin.keyVaultNamespace || 'encryption.__keyVault';
-
   const kmsProviders = {
     local: {
       key: SECRET_KEY,
@@ -41,7 +41,7 @@ function EncryptionPlugin(schema, plugin) {
   );
 
   async function encrypt(value) {
-    const client = mongoose.connection.getClient();
+    const client = connection.getClient();
     const clientEncryption = new ClientEncryption(client, {
       keyVaultNamespace,
       kmsProviders,
@@ -93,7 +93,7 @@ function EncryptionPlugin(schema, plugin) {
   }
 
   async function decrypt(value) {
-    const client = mongoose.connection.getClient();
+    const client = connection.getClient();
     const clientEncryption = new ClientEncryption(client, {
       keyVaultNamespace,
       kmsProviders,


### PR DESCRIPTION
Thanks for this great plugin!

I would like to see this option in your package as it enables you to use it with the package `@nestjs/mongoose`. You can then do something like this:

```
MongooseModule.forRootAsync({
  useFactory: async (configService: ConfigService) => ({
    ...
    connectionFactory: async (connection) => {
      connection.plugin(EncryptionPlugin, {
        connection,
        secret: Buffer.from(secretKey, 'hex'),
        algorithm: 'AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic',
        keyAltName: 'encryption_key',
        keyVaultNamespace: 'encryption.__keyVault',
      })
    }
    ...
  }
})

...
```

Best,
Chris